### PR TITLE
Add license information to page footer

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,9 @@
+{% extends template.self %}
+{% block book_inner %}
+{{ super() }}
+<footer>
+    This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+    All code samples in this work are released to the public domain using the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a>).
+    Please tell us about issues and get involved on <a href="https://github.com/macchina/docs">GitHub</a>!
+</footer>
+{% endblock %}


### PR DESCRIPTION
Adds a simple, text-based footer at the bottom of the content.

Fixes #2