### PR TITLE
Remove header to remedy performance issues

### DIFF
--- a/book.json
+++ b/book.json
@@ -7,7 +7,6 @@
   },
   "plugins": [
     "ga",
-    "header",
     "custom-favicon"
   ],
   "pluginsConfig": {

--- a/layouts/header.html
+++ b/layouts/header.html
@@ -1,3 +1,0 @@
-<header class="main-header">
-  <h1 class="main-header__title"><a href="https://macchina.cc" class="main-header__link"><img src="/images/logo.svg" alt="Macchina logo" class="main-header__logo"></a> Docs</h1>
-</header>

--- a/styles/website.css
+++ b/styles/website.css
@@ -28,7 +28,7 @@ body {
   color: #364149; }
 
 .book-summary {
-  top: 50px; }
+  }
   .book-summary ul.summary li.active > a {
     color: #274287; }
 


### PR DESCRIPTION
When the `header` plugin is enabled navigation makes a lot more requests than needed.  Roughly, each subsequent page navigation makes one more request than the previous.   Requests so soon the browser is requesting the next page 6+ times when you navigate and the browser encounters CPU and memory issues.

/cc @ndiesslin 