### PR TITLE
Make the message linking to GitHub more targeted

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -10,8 +10,9 @@
 {% block book_inner %}
 {{ super() }}
 <footer>
+    Can't find what your are looking for?  <a href="https://github.com/macchina/docs/issue">Open an Issue on GitHub</a> or <a href="https://forum.macchina.cc/">ask on the Forum</a>.
+    <br/><br/>
     This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
-    All code samples in this work are released to the public domain using the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a>).
-    Please tell us about issues and get involved on <a href="https://github.com/macchina/docs">GitHub</a>!
+    All code samples in this work are released to the public domain using the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 Public Domain Dedication</a>.
 </footer>
 {% endblock %}


### PR DESCRIPTION
Before (at end of paragraph):

> Please tell us about issues and get involved on GitHub!

Now (standalone, initial paragraph):

> Can't find what your are looking for?  Open an Issue on GitHub or ask on the Forum.