### PR TITLE
Added 3V Logic

### DIFF
--- a/m2/technical-references/interfaces.md
+++ b/m2/technical-references/interfaces.md
@@ -25,27 +25,27 @@ The following table shows what the function for each pin:
 | ------ |-------------|-------------|
 | 1      | IN 1        |  0-12V Input |
 | 2      | OUT 1       | 12V SOURCE Output|
-| 3      | SCL0        |  |
-| 4      | SDA0        |  |
+| 3      | SCL0        | 3V logic |
+| 4      | SDA0        | 3V logic |
 | 5      | IN 2        | 0-12V Input |
 | 6      | OUT 2       | 12V SOURCE Output |
 | 7      | UART3 TX    | K-LINE or LIN channel 1 |
 | 8      | UART3 RX    |  |
 | 9      | IN 3        |  0-12V Input |
 | 10     | OUT 3       | 12V SOURCE Output |
-| 11     | SPI0 CLK    |  |
-| 12     | SPI0 MISO   |  |
+| 11     | SPI0 CLK    | 3V logic |
+| 12     | SPI0 MISO   | 3V logic |
 | 13     | IN 4        | 0-12V Input |
 | 14     | OUT 4       | 12V SINK Output |
-| 15     | SPI0 CS/USART2RX    |  |
-| 16     | SPIO MOSI           | +12V INPUT |
+| 15     | SPI0 CS/USART2RX    | 3V logic |
+| 16     | SPIO MOSI           | 3V logic |
 | 17     | IN 5        | 0-12V Input |
 | 18     | OUT 5       | 12V SINK Output |
 | 19     | +12VIO      | +12V (switched output) |
 | 20     | +5V         | +5 (constant output)  |
 | 21     | IN 6        | 0-12V Input |
 | 22     | OUT 6       | 12V SINK Output |
-| 23     | +3.3V       | +12V INPUT |
+| 23     | +3.3V       | +3.3V (switched output) |
 | 24     | +12V        | +12V (constant output) |
 | 25     | GND         | Ground  |
 | 26     | GND         | Ground  |


### PR DESCRIPTION
Added 3V logic description to processor pins that appear on connector J5 (MOSI MISO + I2 pins
Added Change to pin 23 +3.3 switched output
I query pins 7 & 8 pin 7 is directly connected to the processor is this correct is associated with K-LINE or LIN channel 1
Also might be prudent to added a not that pins 7 & 8 are 3 volt logic. Otherwise people may connect 5V logic & destroy the processor